### PR TITLE
Update Issues Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Create a report to detail some unexpected behaviour
+title: "[BUG]"
+labels: chore.Bug
+assignees: ''
+
+---
+
+# Bug Report
+
+## Is this bug related to a different issue? If so, please specify
+
+Specify related bugs or issues here.
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+$$ To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+## Additional information
+Add any other information about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest a feature or idea for this project
+title: "[FEAT]"
+labels: chore.Feature, status.ToDiscuss
+assignees: ''
+
+---
+
+# Feature Request
+
+## Is this feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional information
+
+Add any other information or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/functional-requirement.md
+++ b/.github/ISSUE_TEMPLATE/functional-requirement.md
@@ -1,0 +1,18 @@
+---
+name: Functional Requirement
+about: This template helps you to create a functional requirement for a feature within
+  a high-level requirement. This is equivalent to a Requirement of a Feature within
+  an Epic.
+title: "[REQ ID] [FEAT ID] [FR ID]"
+labels: chore.FunctionalRequirements
+assignees: ''
+
+---
+
+# [FR Name]
+
+**Related Feature:** [Link to feature]()
+
+## Description
+
+Enter some information about the functional requirement you are specifying.

--- a/.github/ISSUE_TEMPLATE/high-level-requirement.md
+++ b/.github/ISSUE_TEMPLATE/high-level-requirement.md
@@ -1,0 +1,21 @@
+---
+name: High-Level Requirement
+about: This template helps you to create a high-level requirement. This is equivalent
+  to an Epic.
+title: "[REQ ID]"
+labels: chore.Epic
+assignees: ''
+
+---
+
+# [Requirement Name]
+
+## Description
+
+Enter some information about the high-level requirement you are specifying.
+
+## Features
+
+1. [Link to Feature 1]()
+2. [Link to Feature 2]()
+...

--- a/.github/ISSUE_TEMPLATE/individual-feature.md
+++ b/.github/ISSUE_TEMPLATE/individual-feature.md
@@ -1,0 +1,23 @@
+---
+name: Individual Feature
+about: This template helps you to create individual features within a high-level requirement.
+  This is equivalent to a Feature within an Epic.
+title: "[REQ ID] [FEAT ID]"
+labels: chore.Feature
+assignees: ''
+
+---
+
+# [Feature Name]
+
+**Related High-Level Requirement:** [Link to requirement]()
+
+## Description
+
+Enter some information about the feature you are specifying.
+
+## Features
+
+1. [Link to Feature 1]()
+2. [Link to Feature 2]()
+...

--- a/.github/ISSUE_TEMPLATE/non-functional-requirement.md
+++ b/.github/ISSUE_TEMPLATE/non-functional-requirement.md
@@ -1,0 +1,18 @@
+---
+name: Non Functional Requirement
+about: This template helps you to create a non-functional requirement for a feature
+  within a high-level requirement. This is equivalent to a Requirement of a Feature
+  within an epic.
+title: "[REQ ID] [FEAT ID] [NFR ID]"
+labels: chore.NonFunctionalRequirement
+assignees: ''
+
+---
+
+# [NFR Name]
+
+**Related Feature:** [Link to feature]()
+
+## Description
+
+Enter some information about the non functional requirement you are specifying.


### PR DESCRIPTION
There are currently no GitHub Issues templates that we can use to standardise our Issues creation.

Let's move to create Issues templates to ensure a consistent style of issues across the board to reduce confusion among developers.