### PR TITLE
Fix: Minor bug for Create Question page difficulty dropdown

### DIFF
--- a/peer-prep/src/pages/Questions/CreateQuestionPage/CreateQuestionPage.tsx
+++ b/peer-prep/src/pages/Questions/CreateQuestionPage/CreateQuestionPage.tsx
@@ -164,7 +164,7 @@ export default function CreateQuestionPage() {
           />
           <Select
             label="Difficulty"
-            value="EASY"
+            value={difficulty}
             onChange={(value: string | null) => setDifficulty(value)}
             data={difficultyOptions}
             required


### PR DESCRIPTION
Previously the value for the difficulty dropdown was set to 'EASY' as easy is the default difficulty, but this resulted in the dropdown not displaying changes even when users click on other difficulty levels. This was changed to the difficulty state to ensure that the dropdown can display other difficulty levels as well when clicked. 