### PR TITLE
feat!: Add refresh tokens

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,8 @@ services:
       dockerfile: Dockerfile.public
     ports:
       - '8001:8001'
-    network_mode: bridge
+    networks:
+      - app-network  # Ensure this matches for all services
   matching-service:
     build:
       context: ./matching-service
@@ -30,6 +31,12 @@ services:
   redis:
     build:
       context: ./redis-server
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile    
     ports:
       - "6379:6379"  # Expose Redis port to the host
+    networks:
+      - app-network  # Ensure this matches for all services
+
+networks:
+  app-network:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,3 +27,9 @@ services:
     ports:
       - '5173:5173'
     network_mode: bridge
+  redis:
+    build:
+      context: ./redis-server
+      dockerfile: Dockerfile
+    ports:
+      - "6379:6379"  # Expose Redis port to the host

--- a/redis-server/Dockerfile
+++ b/redis-server/Dockerfile
@@ -1,0 +1,11 @@
+# Use the official Redis image from Docker Hub
+FROM redis:latest
+
+# Optional: Copy a custom Redis configuration file
+# COPY ./redis.conf /usr/local/etc/redis/redis.conf
+
+# Start Redis with the custom config (uncomment if using a config file)
+# CMD ["redis-server", "/usr/local/etc/redis/redis.conf"]
+
+# If not using a custom config, simply run the default Redis server
+CMD ["redis-server"]

--- a/user-service/middlewares/redis.js
+++ b/user-service/middlewares/redis.js
@@ -1,7 +1,7 @@
 import { createClient } from 'redis';
 
 const client = createClient({
-    url: 'redis://localhost:6379' // Adjust the URL if using Docker or a remote instance
+    url: process.env.REDIS_URL || 'redis://redis:6379' // Adjust the URL if using Docker or a remote instance
 });
 
 client.on("ready", () => console.log("Connected to redis!"));

--- a/user-service/middlewares/redis.js
+++ b/user-service/middlewares/redis.js
@@ -1,0 +1,69 @@
+import { createClient } from 'redis';
+
+const client = createClient({
+    url: 'redis://localhost:6379' // Adjust the URL if using Docker or a remote instance
+});
+
+client.on("ready", () => console.log("Connected to redis!"));
+client.on('error', err => console.log('Redis Client Error', err));
+
+if (!client.isOpen) {
+    await client.connect();
+}
+
+export default client;
+
+export async function printAllKeys() {
+    try {
+        const keys = await client.keys('*');
+        console.log('Keys:', keys);
+    } catch (error) {
+        console.error('Error printing all keys:', error);
+    }
+}
+
+export async function addToken(key) {
+    const expiryInSeconds = 60*2
+    const value = 'refreshToken'
+    try {
+        await client.set(key, value, {
+            EX: expiryInSeconds,
+            NX: true
+        });
+        console.log(`Key "${key}" set with expiry of ${expiryInSeconds} seconds.`);
+    } catch (error) {
+        console.error('Error setting key with expiry:', error);
+        throw error;
+    }
+    printAllKeys();
+}
+
+export async function removeToken(key) {
+    try {
+        const result = await client.del(key);
+        console.log('Number of keys deleted:', result);
+        if (result > 0) {
+            console.log('Key deleted:', key);
+        }
+    } catch (error) {
+        console.error('Error deleting key:', error);
+        throw error;
+    }
+    printAllKeys();
+}
+
+export async function tokenExists(key) {
+    printAllKeys();
+    try {
+        const result = await client.exists(key);
+        if (result === 0) {
+            console.log(`Key "${key}" does not exist.`);
+            return false;
+        }
+        console.log(`Key "${key}" exists.`);
+        return true;
+    } catch (error) {
+        console.error('Error checking if key exists:', error);
+        throw error;
+    }
+}

--- a/user-service/package-lock.json
+++ b/user-service/package-lock.json
@@ -14,7 +14,8 @@
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.6.2"
+        "mongoose": "^8.6.2",
+        "redis": "^4.7.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.7"
@@ -45,6 +46,59 @@
       "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -296,6 +350,14 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-support": {
@@ -645,6 +707,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1544,6 +1614,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/rimraf": {

--- a/user-service/package.json
+++ b/user-service/package.json
@@ -17,7 +17,8 @@
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.6.2"
+    "mongoose": "^8.6.2",
+    "redis": "^4.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.7"

--- a/user-service/routers/user-router.js
+++ b/user-service/routers/user-router.js
@@ -1,5 +1,5 @@
 import express from "express"
-import { loginUser, logoutUser, createUser, deleteUser, changePassword, changeDisplayName, getUser } from "../controllers/user-controller.js"
+import { loginUser, logoutUser, createUser, deleteUser, changePassword, changeDisplayName, getUser, authAcccessToken, authRefreshToken, regenerateAccessToken } from "../controllers/user-controller.js"
 import { verifyAuthMiddleware } from "../middlewares/access-control.js"
 
 const userRouter = express.Router()
@@ -12,5 +12,8 @@ userRouter
     .put("/changePassword", verifyAuthMiddleware, changePassword)
     .put("/changeDisplayName", verifyAuthMiddleware, changeDisplayName)
     .get("/:id", getUser)
+    .post("/authAccess", authAcccessToken)
+    .post("/authRefresh", authRefreshToken)
+    .post("/regen", regenerateAccessToken)
 
 export default userRouter

--- a/user-service/services.js
+++ b/user-service/services.js
@@ -22,11 +22,24 @@ export function hashPassword(password) {
 }
 
 export function generateAccessToken({ email, displayName, isAdmin }) {
-    return jwt.sign({ email: email, displayName: displayName, isAdmin: isAdmin }, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '15m' });
+    return jwt.sign({ email: email, displayName: displayName, isAdmin: isAdmin }, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '1m' });
 }
 
 export function verifyAccessToken(token) {
     return jwt.verify(token, process.env.ACCESS_TOKEN_SECRET, (err, user) => {
+        if (err) {
+            return null;
+        }
+        return user;
+    });
+}
+
+export function generateRefreshToken({ email, displayName, isAdmin, isDeleted }) {
+    return jwt.sign({ email: email, displayName: displayName, isAdmin: isAdmin, isDeleted }, process.env.REFRESH_TOKEN_SECRET, { expiresIn: '2m' });
+}
+
+export function verifyRefreshToken(token) {
+    return jwt.verify(token, process.env.REFRESH_TOKEN_SECRET, (err, user) => {
         if (err) {
             return null;
         }

--- a/user-service/services.js
+++ b/user-service/services.js
@@ -21,8 +21,8 @@ export function hashPassword(password) {
     return bcrypt.hashSync(password, salt);
 }
 
-export function generateAccessToken({ email, displayName, isAdmin }) {
-    return jwt.sign({ email: email, displayName: displayName, isAdmin: isAdmin }, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '1m' });
+export function generateAccessToken({ _id, email, displayName, isAdmin, isDeleted }) {
+    return jwt.sign({ userId: _id.toString(), email: email, displayName: displayName, isAdmin: isAdmin, isDeleted }, process.env.ACCESS_TOKEN_SECRET, { expiresIn: '1m' });
 }
 
 export function verifyAccessToken(token) {
@@ -34,8 +34,8 @@ export function verifyAccessToken(token) {
     });
 }
 
-export function generateRefreshToken({ email, displayName, isAdmin, isDeleted }) {
-    return jwt.sign({ email: email, displayName: displayName, isAdmin: isAdmin, isDeleted }, process.env.REFRESH_TOKEN_SECRET, { expiresIn: '2m' });
+export function generateRefreshToken({ _id, email, displayName, isAdmin, isDeleted }) {
+    return jwt.sign({ userId: _id.toString(), email: email, displayName: displayName, isAdmin: isAdmin, isDeleted }, process.env.REFRESH_TOKEN_SECRET, { expiresIn: '2m' });
 }
 
 export function verifyRefreshToken(token) {


### PR DESCRIPTION
Addresses #88

### Description

Currently we only have accessTokens, which do not expire and poses a security vulnerability as whoever obtains the accessToken can access our services indefinitely.
We implement the access-refresh token workflow. (Refer to additional information below to see how it works).
- Access Tokens: Tokens issued during login and regeneration, short-lived tokens used gain accesss to other services
- Refresh Tokens: Tokens issued ONLY during login, long-lived tokens used to regenerate accessTokens.
Currently accessTokens are set with 1min expiration, and refreshTokens with 2min expiration for testing.

Also added endpoints to verify validity of accessToken, refreshToken, and regenerate accessToken.
- Added redis cache folder with its Dockerfile, modified to run with docker compose.
Uses redis cache for whitelisted refreshTokens.

- **Note**: Please modify your `.env` file accordingly to add a new REFRESH_TOKEN_SECRET

### Additional information
1. User logs in, user-service issues a new accessToken and refreshToken stored in cookies.
2. User access other services with accessTokens and is allowed while accessToken is still valid.
3. When accessToken expires, other services will deny access.
4. Frontend needs to call user-service to regenerate a new accessToken.
5. If refreshToken is still valid, user-service issues a newAccessToken.
- If refreshToken is invalid: either refreshToken expired, or was from a previously logged in user that has logged out. User needs to re-login again to get a new refreshToken.
6. User can now access other services again.

![image](https://github.com/user-attachments/assets/c17726bd-2d59-4e8f-b5bc-b20c39a947c1)