### PR TITLE
chore: Offload Question Query to Matching Service from Collaboration Service

### DIFF
--- a/matching-service/controllers/controller.js
+++ b/matching-service/controllers/controller.js
@@ -7,6 +7,7 @@ import {
     ormFindAllPendingUsers,
     ormDeletePendingUserByDocId
 } from "../models/orm.js";
+import axios from 'axios';
 
 export async function onDisconnect(socket) {
     try {

--- a/matching-service/controllers/controller.js
+++ b/matching-service/controllers/controller.js
@@ -143,12 +143,31 @@ export async function onCreateMatch(socket, data, io) {
             console.log(`Common difficulties: ${commonDifficulties}`);
             console.log(`Common categories: ${commonCategories}`);
 
+            // get question first
+            const resp = await axios.get(
+              process.env.QUESTION_SERVICE_ENDPOINT ??
+                'http://localhost:8003/api/question-service/random',
+              {
+                params: {
+                  categoriesId: commonCategories,
+                  difficulty: commonDifficulties,
+                },
+              }
+            );
+
+            const questionInResponse = resp.data['data']['question'];
+            if (questionInResponse === null || questionInResponse === undefined) {
+              console.log('Quesiton is missing');
+              throw new Error('Unable to query for question')
+            }
+
             // Create match object
             const matchObject = {
                 matchId: matchedUser._id.toString(),
                 userIds: [userId, matchedUser.userId],
                 difficulties: commonDifficulties,
                 categoriesId: commonCategories,
+                question: questionInResponse
             }
             console.log(`Match object:`);
             console.log(matchObject);


### PR DESCRIPTION
<!--
    If this PR addresses a particular issue, use:   Addresses #XXXX
    If this PR references a particular issue, use:  References #XXXX

    You may include more than one line of PR references here.
-->

### Description

<!--
    Enter in a short description of your pull request, including:
    1. What the issue is
    2. Why is it an issue
    3. What you have done and what needs to be done
-->

Currently, there is a significant amount of synchronisation issues when the query to the question service is done in collaboration service.

Let's move to shift the querying to the matching service to minimise synchronisation issues for collaboration service.

### Additional information

<!--
    Enter in additional information that you wish to include in your
    PR
-->

Make sure to insert the following key-value pairs into your `.env` file for matching service to be able to properly query the question service endpoint:

```
QUESTION_SERVICE_ENDPOINT=<QUESTION SERVICE ENDPOINT HERE>
```

If you are using this service locally, you might want to set the endpoint to `localhost`.

If you are using this service on the cloud, reference the question service name: `question-service` instead (e.g. `http://question-service/`)