### PR TITLE
chore: Use dotenv

### DIFF
--- a/user-service/package-lock.json
+++ b/user-service/package-lock.json
@@ -12,6 +12,7 @@
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "^4.21.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.6.2"
@@ -432,6 +433,17 @@
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/user-service/package.json
+++ b/user-service/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon --env-file=.env server.js"
+    "dev": "nodemon server.js"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +15,7 @@
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "express": "^4.21.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.2"

--- a/user-service/server.js
+++ b/user-service/server.js
@@ -3,9 +3,13 @@ import cookieParser from 'cookie-parser';
 import userRouter from "./routers/user-router.js"
 import corsMiddleware from "./middlewares/cors.js"
 import { connectToDB } from "./services.js";
+import dotenv from 'dotenv';
 
 // Create express app
 const app = express()
+
+// Setup environment variables
+dotenv.config();
 
 // Initialise middlewares
 app.use(cookieParser())


### PR DESCRIPTION
### Description

Currently user-service uses .env files specified in the node run command.
Now it is moved over to use dotenv.config() for convenience.

